### PR TITLE
Fixing typo in country name

### DIFF
--- a/data/ppch.json
+++ b/data/ppch.json
@@ -2,7 +2,7 @@
     "countryCode": "ch",
     "country": "Switzerland",
     "partyName": {
-        "en": "Pirate Party Swizerland",
+        "en": "Pirate Party Switzerland",
         "ch": "Parti Pirate Suisse && Piratenpartei Schweiz && Partito Pirata Svizzera"
     },
     "type": "national",


### PR DESCRIPTION
Fixing typo in country name (missing "t" in Switzerland)