### PR TITLE
Correct ppuk.json

### DIFF
--- a/data/ppuk.json
+++ b/data/ppuk.json
@@ -2,7 +2,7 @@
     "countryCode": "uk",
     "country": "United Kingdom",
     "partyName": {
-        "en": "Pirate Party United Kingdom",
+        "en": "Pirate Party UK",
         "uk": "Pirate Party UK"
     },
     "type": "national",
@@ -27,7 +27,7 @@
         }
     },
     "membership": {
-        "ppi": "full",
+        "ppi": false,
         "ppeu": false
     },
     "contact": {


### PR DESCRIPTION
* Change name to `Pirate Party UK` - This is the official name [as registered with the UK's Electoral Commission](http://search.electoralcommission.org.uk/English/Registrations/PP770).
* Set `membership.ppi` to `false` - [PPUK resigned from PPI](https://www.pirateparty.org.uk/blogs/editor/ppuk-leaves-ppi) in February 2015.