### PR TITLE
change uk countryCode to gb

### DIFF
--- a/data/ppuk.json
+++ b/data/ppuk.json
@@ -1,5 +1,5 @@
 {
-    "countryCode": "uk",
+    "countryCode": "gb",
     "country": "United Kingdom",
     "partyName": {
         "en": "Pirate Party UK",


### PR DESCRIPTION
According to the doc https://github.com/Pirate-Parties-International/PPI-party-info/blob/master/doc/data_specification.md we use [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1#Current_codes) for the countryCode and that is `gb` for the UK.

> The codes are chosen, according to the ISO 3166/MA, "to reflect the significant, unique component of the country name in order to allow a visual association between country name and country code".[9] For this reason, common components of country names like "Republic", "Kingdom", "United", "Federal" or "Democratic" are normally not used for deriving the code elements. As a consequence, for example, the United Kingdom is officially assigned the alpha-2 code **GB rather than UK**, based on its official name "United Kingdom of Great Britain and Northern Ireland" (although UK is reserved on the request of the United Kingdom).

Maybe we should also change the filename and partyCode to ppgb. (And partyName "language" code.)